### PR TITLE
Display the settings documentation as a table

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,33 +87,35 @@ Following Section contains the Settings you can configure.
 <details style="cursor: pointer;">
     <summary>Settings List</summary>
 
-- Window Title: Lets you set the current Document Title which you e. g. can use with yomichan to tag your created cards
-- WebSocket: URL of the WebSocket to which you want to connect
-- Font Size: Number of px for the Font Size
-- Online Font: Lets you select a Font from a predefined Selection (requires Online Connection in order to work)
-- AFK Timer (s): Seconds after which the timer will automatically pause without Page Interaction (No new Line, Text Selection, Pointer Move)
-- Adjust Timer after AFK: If enabled with subtract the configured AFK Timer (s) value in case Timer was paused due to idle
-- Enable external Clipboard Monitor: If enabled will handle Lines pasted by Extensions like "Clipboard Inserter" or "lap-clipboard-inserter"
-- Store Stats persistently: If enabled will store Time value etc. in your local Browser Storage so that it will be available after tab reloads etc.
-- Store Notes persistently: If enabled will store Notes in your local Browser Storage so that they will be available after tab reloads etc.
-- Store Lines persistently: If enabled will store received/pasted Lines etc. in your local Browser Storage so that they will be available after tab reloads etc.
-- Store Action History persistently: If enabled will store revertible Actions etc. in your local Browser Storage so that they will be available after tab reloads etc.
-- Enable Paste: If enabled will allow to manually paste new Lines to the Page
-- Flash on missed Line: If enabled will show a short page flash in case your Timer is paused and you received/pasted new Lines which were therefore ignored
-- Allow new Line during Pause: If enabled will allow to receive/paste new Lines even with paused Timer
-- Autostart Timer during Pause: If enabled will automatically start the timer when it is paused and new Lines were received/pasted
-- Prevent Last Line Duplicate: If enabled will prevent the insertion/pasting of a Line if the text is equal to the last Line
-- Prevent Global Duplicate: If enabled will prevent the insertion/pasting of a Line if the text line already exists in any other Line
-- Display Text vertically: If enabled will display Lines vertically instead horizontally
-- Reverse Line Order: If enabled new Lines will be appended on top (horizonal mode) / left (vertical mode) instead of bottom/right
-- Preserve Whitespace: If enabled will preserve Whitespace like new line characters inside Text instead of printing out a single Line etc.
-- Remove all Whitespace: If enabled all Whitespace (e. g. space, new Line characters, tab character etc.) will be removed from Lines before inserting them
-- Show Timer: If enabled will display the current passed (active) time on the Page in the header
-- Show Speed: If enabled will display the current characters per hour in the header
-- Show Character Count: If enabled will display the current number  of displayed characters on the Page in the header
-- Show Line Count: If enabled will display the current number  of inserted lines on the Page in the header
-- Blur Stats: If enabled will blue the displayed stats (unblur on hover)
-- Custom CSS: Lets you insert custom CSS rules to customize the Page further
+| Setting | Description |
+|-|-|
+| Window Title | Lets you set the current Document Title which you e. g. can use with yomichan to tag your created cards |
+| WebSocket | URL of the WebSocket to which you want to connect |
+| Font Size | Number of px for the Font Size |
+| Online Font | Lets you select a Font from a predefined Selection (requires Online Connection in order to work) |
+| AFK Timer (s) | Seconds after which the timer will automatically pause without Page Interaction (No new Line, Text Selection, Pointer Move) |
+| Adjust Timer after AFK | If enabled with subtract the configured AFK Timer (s) value in case Timer was paused due to idle |
+| Enable external Clipboard Monitor | If enabled will handle Lines pasted by Extensions like "Clipboard Inserter" or "lap-clipboard-inserter" |
+| Store Stats persistently | If enabled will store Time value etc. in your local Browser Storage so that it will be available after tab reloads etc. |
+| Store Notes persistently | If enabled will store Notes in your local Browser Storage so that they will be available after tab reloads etc. |
+| Store Lines persistently | If enabled will store received/pasted Lines etc. in your local Browser Storage so that they will be available after tab reloads etc. |
+| Store Action History persistently | If enabled will store revertible Actions etc. in your local Browser Storage so that they will be available after tab reloads etc. |
+| Enable Paste | If enabled will allow to manually paste new Lines to the Page |
+| Flash on missed Line | If enabled will show a short page flash in case your Timer is paused and you received/pasted new Lines which were therefore ignored |
+| Allow new Line during Pause | If enabled will allow to receive/paste new Lines even with paused Timer |
+| Autostart Timer during Pause | If enabled will automatically start the timer when it is paused and new Lines were received/pasted |
+| Prevent Last Line Duplicate | If enabled will prevent the insertion/pasting of a Line if the text is equal to the last Line |
+| Prevent Global Duplicate | If enabled will prevent the insertion/pasting of a Line if the text line already exists in any other Line |
+| Display Text vertically | If enabled will display Lines vertically instead horizontally |
+| Reverse Line Order | If enabled new Lines will be appended on top (horizonal mode) / left (vertical mode) instead of bottom/right |
+| Preserve Whitespace | If enabled will preserve Whitespace like new line characters inside Text instead of printing out a single Line etc. |
+| Remove all Whitespace | If enabled all Whitespace (e. g. space, new Line characters, tab character etc.) will be removed from Lines before inserting them |
+| Show Timer | If enabled will display the current passed (active) time on the Page in the header |
+| Show Speed | If enabled will display the current characters per hour in the header |
+| Show Character Count | If enabled will display the current number  of displayed characters on the Page in the header |
+| Show Line Count | If enabled will display the current number  of inserted lines on the Page in the header |
+| Blur Stats | If enabled will blue the displayed stats (unblur on hover) |
+| Custom CSS | Lets you insert custom CSS rules to customize the Page further |
 
 </details>
 


### PR DESCRIPTION
Does what the title says.

This is a prerequisite to a [future PR that rewords the settings quite a bit](https://github.com/Aquafina-water-bottle/texthooker-ui/tree/readme_settings#available-settings) (which maybe more controversial than this PR, hence why this is separate.)