### PR TITLE
Add selecting lines with meta key (command/Windows key) for macOS compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ There are multiple ways of deleting a line:
 -   Click on the "Delete last Line" Icon in the header
 -   Click on the "Reset Lines" / "Reset Data" / "Reset All" Icon in the settings menu
 -   Highlight a line and press the "Delete" key on the keyboard
--   Select a Line for deletion by holding the "CTRL" key on the keyboard and double click on it (you can press "Escape" to unselect lines again). Afterwards click on the "Remove selected Lines" icon in the header
+-   Select a Line for deletion by holding the "CTRL" key (or "command" key on macOS) on the keyboard and double click on it (you can press "Escape" to unselect lines again). Afterwards click on the "Remove selected Lines" icon in the header
 
 ### How can I edit a line?
 

--- a/src/components/Line.svelte
+++ b/src/components/Line.svelte
@@ -44,7 +44,7 @@
 	function handleDblClick(event: MouseEvent) {
 		window.getSelection()?.removeAllRanges();
 
-		if (event.ctrlKey) {
+		if (event.ctrlKey || event.metaKey) {
 			if (isSelected) {
 				isSelected = false;
 				dispatch('deselected', line.id);


### PR DESCRIPTION
On macOS, it's impossible to double click holding the ctrl key as that opens the context menu in most apps. Instead, the command key is the ctrl equivalent. This is detected by event.metaKey which otherwise maps to the "Windows" key, which is not likely to be an issue anyway.